### PR TITLE
Fix SlackBotWorker to return error on Slack Web API

### DIFF
--- a/lib/SlackBotWorker/apiStorage.js
+++ b/lib/SlackBotWorker/apiStorage.js
@@ -229,14 +229,16 @@ function Storage(){
     return {
         process: function(url, formData, cb){
             var entity = storage[url];
+            var response;
             if(!entity){
-                return cb(null, null)
+                return cb(null, null);
             }
             if(entity.filter){
-                cb(null, entity.filter(formData));
+                response = entity.filter(formData);
             }else{
-                cb(null, entity.data || entity)
+                response = entity.data || entity;
             }
+            cb((response.ok === false) ? response.error : null, response);
         },
         setData (key, value){
             if(!storage[key]){

--- a/tests/updateApiResponseJasmineSpec.js
+++ b/tests/updateApiResponseJasmineSpec.js
@@ -85,3 +85,37 @@ describe('change api data for action with extending', ()=>{
     });
 });
 
+describe('mock api error case', ()=>{
+    beforeEach((done)=>{
+        this.controller = Botmock({
+            debug: false,
+        });
+        this.bot = this.controller.spawn({type: 'slack'});
+
+        this.bot.api.setData('users.list', {ok: false, error: 'not_authed'});
+        this.bot.api.setData('channels.info', {channel1: {ok: false, error: 'channel_not_found'}});
+        done();
+    });
+
+    it('should return error in users.list call', (done)=>{
+        this.bot.api.callAPI('users.list', {}, (err, data)=>{
+            expect(err).toBe('not_authed');
+            done();
+        })
+    });
+
+    it('should return error in channels.info call', (done)=>{
+        this.bot.api.callAPI('channels.info', {channel: 'channel1'}, (err, data)=>{
+            expect(err).toBe('channel_not_found');
+            done();
+        })
+    });
+
+    it('should not return error when ok is not specified', (done)=>{
+        this.bot.api.setData('users.list', {members: [{id: '2'}]});
+        this.bot.api.callAPI('users.list', {}, (err, data)=>{
+            expect(err).toBeNull();
+            done();
+        })
+    });
+});

--- a/tests/updateApiResponseMochaSpec.js
+++ b/tests/updateApiResponseMochaSpec.js
@@ -86,6 +86,40 @@ describe('change api data for action with extending', ()=>{
     });
 });
 
+describe('mock api error case', ()=>{
+    beforeEach((done)=>{
+        this.controller = Botmock({
+            debug: false,
+        });
+        this.bot = this.controller.spawn({type: 'slack'});
+
+        this.bot.api.setData('users.list', {ok: false, error: 'not_authed'});
+        this.bot.api.setData('channels.info', {channel1: {ok: false, error: 'channel_not_found'}});
+        done();
+    });
+
+    it('should return error in users.list call', (done)=>{
+        this.bot.api.callAPI('users.list', {}, (err, data)=>{
+            assert.equal(err, 'not_authed')
+            done();
+        })
+    });
+
+    it('should return error in channels.info call', (done)=>{
+        this.bot.api.callAPI('channels.info', {channel: 'channel1'}, (err, data)=>{
+            assert.equal(err, 'channel_not_found')
+            done();
+        })
+    });
+
+    it('should not return error when ok is not specified', (done)=>{
+        this.bot.api.setData('users.list', {members: [{id: '2'}]});
+        this.bot.api.callAPI('users.list', {}, (err, data)=>{
+            assert.equal(err, null)
+            done();
+        })
+    });
+});
 
 describe('api urls', ()=>{
     beforeEach(()=>{


### PR DESCRIPTION
I tried to test error on Slack Web API, but found that botkit-mock don’t return error to callback function.

If `ok` is false, botkit returns `error` in API response ([Slack_web_api.js#L242](https://github.com/howdyai/botkit/blob/master/lib/Slack_web_api.js#L242)).

For example, `err` should be equal to `’error_message’` in below code.
However, botkit-mock always returns `null`.

```
this.bot.api.setData('chat.postMessage', {
  ok : false,
  error : 'error_message'
});

this.bot.api.chat.postMessage({ channel : 'C01234567', text: foo }, (err, data) => {
  console.log(err); // null
  console.log(data);
});
```
So I modified [storage.process](https://github.com/gratifyguy/botkit-mock/blob/master/lib/SlackBotWorker/apiStorage.js#L230) in `lib/SlackBotWorker/apiStorage.js`.

It returns error only when `ok` is specified and `ok === false`. It's not necessary to include `ok: true` in every mock API response.

Please review this change.