### PR TITLE
Add slash command reply functions

### DIFF
--- a/lib/SlackBotWorker/index.js
+++ b/lib/SlackBotWorker/index.js
@@ -58,6 +58,82 @@ function SlackBotWorker(bot, botkit, config){
         });
     }
 
+    bot.replyPublic = function(src, resp, cb) {
+        var msg = {};
+
+        if (typeof(resp) == 'string') {
+            msg.text = resp;
+        } else {
+            msg = resp;
+        }
+
+        msg.channel = src.channel;
+
+        // if source message is in a thread, reply should also be in the thread
+        if (src.thread_ts) {
+            msg.thread_ts = src.thread_ts;
+        }
+
+        msg.response_type = 'in_channel';
+
+        var requestOptions = {
+            uri: src.response_url,
+            method: 'POST',
+            json: msg
+        };
+        bot.api.callAPI('replyPublic', requestOptions, function (err, resp, body) {
+            /**
+             * Do something?
+             */
+            if (err) {
+                botkit.log.error('Error sending slash command response:', err);
+                cb && cb(err);
+            } else {
+                cb && cb();
+            }
+        });
+    }
+
+    bot.replyPublicDelayed = bot.replyPublic;
+
+    bot.replyPrivate = function(src, resp, cb) {
+        var msg = {};
+
+        if (typeof(resp) == 'string') {
+            msg.text = resp;
+        } else {
+            msg = resp;
+        }
+
+        msg.channel = src.channel;
+
+        // if source message is in a thread, reply should also be in the thread
+        if (src.thread_ts) {
+            msg.thread_ts = src.thread_ts;
+        }
+
+        msg.response_type = 'ephemeral';
+
+        var requestOptions = {
+            uri: src.response_url,
+            method: 'POST',
+            json: msg
+        };
+        bot.api.callAPI('replyPrivate', requestOptions, function (err, resp, body) {
+            /**
+             * Do something?
+             */
+            if (err) {
+                botkit.log.error('Error sending slash command response:', err);
+                cb && cb(err);
+            } else {
+                cb && cb();
+            }
+        });
+    }
+
+    bot.replyPrivateDelayed = bot.replyPrivate;
+
     bot.startConversationInThread = function(message, cb) {
         // make replies happen in a thread
         if (!message.thread_ts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit-mock",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Write tests for botkit.",
   "main": "lib/Botmock.js",
   "scripts": {

--- a/tests/slash_command/slashCommand.js
+++ b/tests/slash_command/slashCommand.js
@@ -1,0 +1,18 @@
+module.exports = function(controller){
+    controller.on('slash_command', function(bot, message) {
+        switch(message.command) {
+            case '/public':
+                bot.replyPublic(message, 'This is a public reply to the ' + message.command + ' slash command!');
+                break;
+            case '/private':
+                bot.replyPrivate(message, 'This is a private reply to the ' + message.command + ' slash command!');
+                break;
+            case '/public_delayed':
+                bot.replyPublicDelayed(message, 'This is a public reply to the ' + message.command + ' slash command!');
+                break;
+            case '/private_delayed':
+                bot.replyPrivateDelayed(message, 'This is a private reply to the ' + message.command + ' slash command!');
+                break;
+        }
+    });
+}

--- a/tests/slash_command/slashCommandJasmineSpec.js
+++ b/tests/slash_command/slashCommandJasmineSpec.js
@@ -1,0 +1,101 @@
+'use strict';
+const Botmock = require('../../lib/Botmock');
+const fileBeingTested = require("./slashCommand");
+
+describe("slash command tests",()=>{
+    afterEach(()=>{
+        //clean up botkit tick interval
+        this.controller.shutdown()
+    });
+
+    beforeEach((done)=>{
+        this.userInfo = {
+            slackId: 'user123',
+            channel: 'channel123',
+        };
+
+        this.sequence = [
+            {
+                type: 'slash_command',
+                user: this.userInfo.slackId, //user required for each direct message
+                channel: this.userInfo.channel, // user channel required for direct message
+                messages:[
+                    {
+                        text: 'text',
+                        isAssertion: true,
+                        command: '',
+                        //response_url : 'https://hooks.slack.com/commands/foo/bar'
+                    }
+                ]
+            }
+        ];
+        this.controller = Botmock({
+            debug: false,
+            log: false,
+        });
+
+        this.bot = this.controller.spawn({
+            type: 'slack',
+        });
+
+        fileBeingTested(this.controller);
+        done()
+    });
+
+    describe('replyPublic()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPublic\']', ()=>{
+            this.sequence[0].messages[0].command = '/public';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPublic'][0].json;
+                expect(reply.text).toBe('This is a public reply to the /public slash command!');
+                expect(reply.response_type).toBe('in_channel', 'should be public message');
+                jasmine.asyncSpecDone();
+            }).catch((err) => { console.error(err); })
+        });
+        jasmine.asyncSpecWait();
+    });
+
+    describe('replyPrivate()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPrivate\']', ()=>{
+            this.sequence[0].messages[0].command = '/private';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPrivate'][0].json;
+                expect(reply.text).toBe('This is a private reply to the /private slash command!');
+                expect(reply.response_type).toBe('ephemeral', 'should be private message');
+                jasmine.asyncSpecDone();
+            }).catch((err) => { console.error(err); })
+        });
+        jasmine.asyncSpecWait();
+    });
+
+    describe('replyPublicDelayed()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPublic\']', ()=>{
+            this.sequence[0].messages[0].command = '/public_delayed';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPublic'][0].json;
+                expect(reply.text).toBe('This is a public reply to the /public_delayed slash command!');
+                expect(reply.response_type).toBe('in_channel', 'should be public message');
+                jasmine.asyncSpecDone();
+            }).catch((err) => { console.error(err); })
+        });
+        jasmine.asyncSpecWait();
+    });
+
+    describe('replyPrivateDelayed()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPrivate\']', ()=>{
+            this.sequence[0].messages[0].command = '/private_delayed';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPrivate'][0].json;
+                expect(reply.text).toBe('This is a private reply to the /private_delayed slash command!');
+                expect(reply.response_type).toBe('ephemeral', 'should be private message');
+                jasmine.asyncSpecDone();
+            }).catch((err) => { console.error(err); })
+        });
+        jasmine.asyncSpecWait();
+    });
+});
+

--- a/tests/slash_command/slashCommandMochaSpec.js
+++ b/tests/slash_command/slashCommandMochaSpec.js
@@ -1,0 +1,94 @@
+'use strict';
+const assert = require('assert');
+const Botmock = require('../../lib/Botmock');
+const fileBeingTested = require("./slashCommand");
+
+describe("slash command tests",()=>{
+    afterEach(()=>{
+        //clean up botkit tick interval
+        this.controller.shutdown()
+    });
+
+    beforeEach((done)=>{
+        this.userInfo = {
+            slackId: 'user123',
+            channel: 'channel123',
+        };
+
+        this.sequence = [
+            {
+                type: 'slash_command',
+                user: this.userInfo.slackId, //user required for each direct message
+                channel: this.userInfo.channel, // user channel required for direct message
+                messages:[
+                    {
+                        text: 'text',
+                        isAssertion: true,
+                        command: '',
+                        //response_url : 'https://hooks.slack.com/commands/foo/bar'
+                    }
+                ]
+            }
+        ];
+        this.controller = Botmock({
+            debug: false,
+            log: false,
+        });
+
+        this.bot = this.controller.spawn({
+            type: 'slack',
+        });
+
+        fileBeingTested(this.controller);
+        done()
+    });
+
+    describe('replyPublic()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPublic\']', ()=>{
+            this.sequence[0].messages[0].command = '/public';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPublic'][0].json;
+                assert.equal(reply.text, 'This is a public reply to the /public slash command!');
+                assert.equal(reply.response_type, 'in_channel', 'should be public message');
+            }).catch((err) => { console.error(err); })
+        });
+    });
+
+    describe('replyPrivate()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPrivate\']', ()=>{
+            this.sequence[0].messages[0].command = '/private';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPrivate'][0].json;
+                assert.equal(reply.text, 'This is a private reply to the /private slash command!');
+                assert.equal(reply.response_type, 'ephemeral', 'should be private message');
+            }).catch((err) => { console.error(err); })
+        });
+    });
+
+    describe('replyPublicDelayed()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPublic\']', ()=>{
+            this.sequence[0].messages[0].command = '/public_delayed';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPublic'][0].json;
+                assert.equal(reply.text, 'This is a public reply to the /public_delayed slash command!');
+                assert.equal(reply.response_type, 'in_channel', 'should be public message');
+            }).catch((err) => { console.error(err); })
+        });
+    });
+
+    describe('replyPrivateDelayed()', () => {
+        it('should store reply message in bot.api.logByKey[\'replyPrivate\']', ()=>{
+            this.sequence[0].messages[0].command = '/private_delayed';
+
+            return this.bot.usersInput(this.sequence).then(()=>{
+                const reply = this.bot.api.logByKey['replyPrivate'][0].json;
+                assert.equal(reply.text, 'This is a private reply to the /private_delayed slash command!');
+                assert.equal(reply.response_type, 'ephemeral', 'should be private message');
+            }).catch((err) => { console.error(err); })
+        });
+    });
+});
+


### PR DESCRIPTION
Implemented slash command related functions in lib/SlackBotWorker/index.js.

- bot.replyPublic()
- bot.replyPrivate()
- bot.replyPublicDelayed()
- bot.replyPrivateDelayed()
- raise version to 0.1.1

"Delayed" functions and the other functions are equal because `botkit-mock` don't distinguish timing of reply. 
All four functions store reply message in `bot.api.logByKey`, just like `replyInteractive()`.

(Added test files for this change in `tests/slash_command/`. Is that OK?)