### PR TITLE
Fix timeout parameter on messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ beforeEach(()=>{
     - `isAssertion` indicates which conversation response array to return in `.then()` in multi-user testing. (required) (boolean)
     - `deep` indicates the index of the conversation response to return in `.then()`. 0 (default) is the last response, 1 is the second-to-last, etc.. (integer)
     - `timeout` set timeout for message in milliseconds (integer)
+    - `waitBefore` alias for `timeout`, indicates how many milliseconds to wait before sending the message to the bot (integer)
+    - `waitAfter` indicates how many milliseconds to wait for the bot response, useful for long-running commands (integer)
     - `text` the message's text (string)
     - `channel` indicates the channel the message was sent in. This overrides the channel defined in `usersInput` for this current message. (string)
     - ...any other fields you may be testing for including `attachments`, `callback_id`, etc...

--- a/lib/BotmockWorker.js
+++ b/lib/BotmockWorker.js
@@ -102,11 +102,11 @@ function BotmockWorker (botkit, config) {
 							} else {
 								cb(null);
 							}
-						}, config.afterProcessingUserMessageTimeout);
+						}, message.timeout || config.afterProcessingUserMessageTimeout);
 					};
 					
 					//add default timeout for async workflow
-					setTimeout(logic, message.timeout || config.beforeProcessingUserMessageTimeout);
+					setTimeout(logic, 0 || config.beforeProcessingUserMessageTimeout);
 				});
 			});
 		});

--- a/lib/BotmockWorker.js
+++ b/lib/BotmockWorker.js
@@ -102,11 +102,11 @@ function BotmockWorker (botkit, config) {
 							} else {
 								cb(null);
 							}
-						}, message.timeout || config.afterProcessingUserMessageTimeout);
+						}, message.waitAfter || config.afterProcessingUserMessageTimeout);
 					};
 					
 					//add default timeout for async workflow
-					setTimeout(logic, 0 || config.beforeProcessingUserMessageTimeout);
+					setTimeout(logic, message.waitBefore || message.timeout || config.beforeProcessingUserMessageTimeout);
 				});
 			});
 		});

--- a/tests/slash_command/slashCommand.js
+++ b/tests/slash_command/slashCommand.js
@@ -16,7 +16,7 @@ module.exports = function (controller) {
 			case '/private_long_running':
 				setTimeout(function () { 
 					bot.reply(message, 'Timeout reply'); 
-				}, 500);
+				}, 200);
 				break;
 		}
 	});

--- a/tests/slash_command/slashCommand.js
+++ b/tests/slash_command/slashCommand.js
@@ -13,6 +13,11 @@ module.exports = function (controller) {
 			case '/private_delayed':
 				bot.replyPrivateDelayed(message, 'This is a private reply to the ' + message.command + ' slash command!');
 				break;
+			case '/private_long_running':
+				setTimeout(function () { 
+					bot.reply(message, 'Timeout reply'); 
+				}, 500);
+				break;
 		}
 	});
 };

--- a/tests/slash_command/slashCommandJasmineSpec.js
+++ b/tests/slash_command/slashCommandJasmineSpec.js
@@ -101,7 +101,7 @@ describe('slash command tests', () => {
 	describe('reply with timeout', () => {
 		it('should wait for the command result given a timout', () => {
 			this.sequence[0].messages[0].command = '/private_long_running';
-			this.sequence[0].messages[0].timeout = 600;
+			this.sequence[0].messages[0].waitAfter = 300;
 			
 			return this.bot.usersInput(this.sequence).then((msg) => {
 				expect(msg.text).toBe('Timeout reply');

--- a/tests/slash_command/slashCommandJasmineSpec.js
+++ b/tests/slash_command/slashCommandJasmineSpec.js
@@ -97,5 +97,18 @@ describe('slash command tests', () => {
 		});
 		jasmine.asyncSpecWait();
 	});
+
+	describe('reply with timeout', () => {
+		it('should wait for the command result given a timout', () => {
+			this.sequence[0].messages[0].command = '/private_long_running';
+			this.sequence[0].messages[0].timeout = 600;
+			
+			return this.bot.usersInput(this.sequence).then((msg) => {
+				expect(msg.text).toBe('Timeout reply');
+				jasmine.asyncSpecDone();
+			}).catch((err) => { console.error(err); });
+		});
+		jasmine.asyncSpecWait();
+	});
 });
 

--- a/tests/slash_command/slashCommandMochaSpec.js
+++ b/tests/slash_command/slashCommandMochaSpec.js
@@ -94,7 +94,7 @@ describe('slash command tests', () => {
 	describe('reply with timeout', () => {
 		it('should wait for the command result given a timout', (done) => {
 			this.sequence[0].messages[0].command = '/private_long_running';
-			this.sequence[0].messages[0].timeout = 600;
+			this.sequence[0].messages[0].waitAfter = 300;
 			
 			return this.bot.usersInput(this.sequence).then((msg) => {
 				assert.equal(msg.text, 'Timeout reply');

--- a/tests/slash_command/slashCommandMochaSpec.js
+++ b/tests/slash_command/slashCommandMochaSpec.js
@@ -90,5 +90,17 @@ describe('slash command tests', () => {
 			}).catch((err) => { console.error(err); });
 		});
 	});
+
+	describe('reply with timeout', () => {
+		it('should wait for the command result given a timout', (done) => {
+			this.sequence[0].messages[0].command = '/private_long_running';
+			this.sequence[0].messages[0].timeout = 600;
+			
+			return this.bot.usersInput(this.sequence).then((msg) => {
+				assert.equal(msg.text, 'Timeout reply');
+				done();
+			}).catch((err) => { console.error(err); });
+		});
+	});
 });
 


### PR DESCRIPTION
Fixes the issue discussed [here](https://github.com/gratifyguy/botkit-mock/issues/30#issuecomment-398078025).
With tests (async tests do add a second to the overall duration of the tests run, so we can consider lower timeout values if tests speed something important to you guys).

